### PR TITLE
Example service and command objects

### DIFF
--- a/commands.conf
+++ b/commands.conf
@@ -1,0 +1,29 @@
+object CheckCommand "check_sslscan" {
+       import "plugin-check-command"
+
+       command = [ PluginDir + "check_sslscan" ]
+
+       arguments = {
+       		 "-H" = {
+		      value = "$domain_check$"
+		      description = "Domain to test"
+		 }
+		 "-w" = {
+		      value = "$grade_warning$"
+		      description = "Grade at which to warn"
+		 }
+		 "-c" = {
+		      value = "$grade_critical$"
+		      description = "Grade to consider critical"
+		 }
+		 "-a" = { 
+		      value = "$max_cache_age$"
+		      description = "Maximum cache age in days"
+		 }
+		 "-ip" = {
+		      value = "$ip_address$"
+		       description = "IP address to test"
+		 }
+        }
+}
+       

--- a/services.conf
+++ b/services.conf
@@ -5,4 +5,4 @@ object Service "example SSL scan" {
        check_timeout = 5m
        vars.domain_check = "example.com"
        vars.max_cache_age = 1
-}       
+}

--- a/services.conf
+++ b/services.conf
@@ -1,0 +1,8 @@
+object Service "example SSL scan" {
+       host_name = "localhost"
+       check_command = "check_sslscan"
+       check_interval = 1d
+       check_timeout = 5m
+       vars.domain_check = "example.com"
+       vars.max_cache_age = 1
+}       


### PR DESCRIPTION
If they're of interest, I've added some example services.conf and commands.conf files for the check_sslscan script that match the ones I'm using in a production system. This should make it a little easier for users to get the plugin into use.